### PR TITLE
Patch for transform to resolve Issue #8

### DIFF
--- a/lib/pyproj/__init__.py
+++ b/lib/pyproj/__init__.py
@@ -476,6 +476,12 @@ def transform(p1, p2, x, y, z=None, radians=False):
     >>> "%12.3f %12.3f" % (x2,y2)
     ' 1402285.991  5076292.423'
     """
+    # check that p1 and p2 are from the Proj class
+    if not isinstance(p1, Proj):
+        raise TypeError("p1 must be a Proj class")
+    if not isinstance(p2, Proj):
+        raise TypeError("p2 must be a Proj class")
+
     # process inputs, making copies that support buffer API.
     inx, xisfloat, xislist, xistuple = _copytobuffer(x)
     iny, yisfloat, yislist, yistuple = _copytobuffer(y)

--- a/unittest/test.py
+++ b/unittest/test.py
@@ -47,6 +47,24 @@ class BasicTest(unittest.TestCase):
       self.assertAlmostEqual(point_geog[0], point_geog2[0])
       self.assertAlmostEqual(point_geog[1], point_geog2[1])
 
+class Issue8Test(unittest.TestCase):
+    # Test for "Segmentation fault on pyproj.transform #8"
+    # https://github.com/jswhit/pyproj/issues/8
+
+    def setUp(self):
+       self.p = Proj(init='epsg:4269')
+    
+    def test_tranform_none_1st_parmeter(self):
+    # test should raise Type error if projections are not of Proj classes
+    # version 1.9.4 produced AttributeError, now should raise TypeError
+       with self.assertRaises(TypeError):
+          transform(None, self.p, -74, 39)
+
+    def test_tranform_none_2nd_parmeter(self):
+    # test should raise Type error if projections are not of Proj classes
+    # version 1.9.4 has a Segmentation Fault, now should raise TypeError
+       with self.assertRaises(TypeError):
+          transform(self.p, None, -74, 39)
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This is a patch to `transform()` to check if p1 and p2 are instances of the Proj class.  Tests are also provided for unittest.

Hopefully, resolving issue #8.