### PR TITLE
Add setuptools to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import sys, os, glob, subprocess
 from distutils import ccompiler, sysconfig
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 
 deps = glob.glob('src/*.c')
 extensions = [Extension("pyproj._proj",deps+['_proj.c'],include_dirs = ['src'])]


### PR DESCRIPTION
I suggest using setuptools, rather than raw distutils, in the setup.py.

setuptools is pretty much ubiquitous these days, so it's not likely to be a problem. And pip requires setuptools, so anyone doing ``pip install`` is guaranteed to have it.

But it's a better option, particularly on Windows, where recent setuptools can properly find the "MS VS compiler for python2.7", whereas distutils cannot.