### PR TITLE
Don't pass valueless parameters to Geod

### DIFF
--- a/lib/pyproj/__init__.py
+++ b/lib/pyproj/__init__.py
@@ -694,6 +694,10 @@ class Geod(_proj.Geod):
         ellpsd = {}
         if initstring is not None:
             for kvpair in initstring.split():
+                # Actually only +a and +b are needed
+                # We can ignore safely any parameter that doesn't have a value
+                if kvpair.find('=') == -1:
+                    continue
                 k,v = kvpair.split('=')
                 k = k.lstrip('+')
                 if k in ['a','b','rf','f','es','e']:


### PR DESCRIPTION
As the code uses a dict to pass parameters, it tries to split
every parameter into name and value. If a valueless parameter
is given, ex: +no_defs, it breaks the split.
We can safely ignore any parameter that is not +a and +b, so
the easiest workaround for this issue is to just ignore the
problematic parameter