### PR TITLE
fix a division that is no longer accaptable for cython 0.23 while 0.2…

### DIFF
--- a/_proj.pyx
+++ b/_proj.pyx
@@ -340,7 +340,7 @@ def _transform(Proj p1, Proj p2, inx, iny, inz, radians):
     yy = <double *>ydata
     if inz is not None:
         zz = <double *>zdata
-    npts = buflenx/8
+    npts = buflenx//8
     if not radians and p1.is_latlong():
         for i from 0 <= i < npts:
             xx[i] = xx[i]*_dg2rad


### PR DESCRIPTION
Hi Jeff,

today I found this tiny little issue in the _proj.pyx file that actually caused the pyproj package to fail its build on fedora rawhide. It gives this error:

Error compiling Cython file:
------------------------------------------------------------
...
        raise RuntimeError('x,y and z must be same size')
    xx = <double *>xdata
    yy = <double *>ydata
    if inz is not None:
        zz = <double *>zdata
    npts = buflenx/8
                 ^
------------------------------------------------------------

This pull request fixes this division which is no longer accaptable for cython 0.23 while 0.22 still accpted it (It should be an integer division).