### PR TITLE
Fix for string type test

### DIFF
--- a/lib/pyproj/__init__.py
+++ b/lib/pyproj/__init__.py
@@ -54,6 +54,13 @@ set_datapath =  _proj.set_datapath
 from array import array
 import os, math
 #import numpy as np
+
+# Python 2/3 compatibility
+if sys.version_info[0] == 2:	 	# Python 2
+   string_types = (basestring,)
+else: 			   		# Python 3
+   string_types = (str,)
+
 pj_list={
 'aea': "Albers Equal Area",
 'aeqd': "Azimuthal Equidistant",
@@ -320,7 +327,7 @@ class Proj(_proj.Proj):
                 raise RuntimeError('no projection control parameters specified')
             else:
                 projstring = _dict2string(kwargs)
-        elif type(projparams) == str or unicode:
+        elif isinstance(projparams, string_types):
             # if projparams is a string or a unicode string, interpret as a proj4 init string.
             projstring = projparams
         else: # projparams a dict


### PR DESCRIPTION
This line in `Proj.__new__()` to test if `projparms` is a string was always true because `or unicode` statement short circuited the logic. This would cause projparms as a dictionary to be passed to projstring.  That caused the projstring.count() to fail, because dictionaries don't have that function.

I recoded this so that the six package is NOT needed.

This problem was discovered because the unittest testProjAwips221 was failing.