### PR TITLE
fix segmentation fault

### DIFF
--- a/_proj.pyx
+++ b/_proj.pyx
@@ -26,6 +26,15 @@ cdef extern from "geodesic.h":
                double lat1, double lon1, double lat2, double lon2,\
                double* ps12, double* pazi1, double* pazi2)
 
+# define part of the struct PJconsts from projects.h
+ctypedef void (*c_func_type)()
+
+ctypedef struct PJconsts:
+    void *ctx
+    c_func_type fwd
+    c_func_type inv
+    # ignore all other components of this struct, we don't need them  
+
 cdef extern from "proj_api.h":
     ctypedef struct projUV:
         double u
@@ -201,6 +210,9 @@ cdef class Proj:
                 continue
             projxyin.u = xdatab[i]
             projxyin.v = ydatab[i]
+            projpj2 = <PJconsts *> self.projpj
+            if (projpj2.inv == NULL):
+                raise RuntimeError('inverse projection undefined')
             projlonlatout = pj_inv(projxyin,self.projpj)
             if errcheck:
                 err = pj_ctx_get_errno(self.projctx)

--- a/unittest/test.py
+++ b/unittest/test.py
@@ -1,7 +1,7 @@
 """Rewrite part of test.py in pyproj in the form of unittests."""
 import unittest
 from pyproj import Geod, Proj, transform
-
+from pyproj import pj_list # , pj_ellps
 
 class BasicTest(unittest.TestCase):
 
@@ -72,5 +72,28 @@ class Geod_NoDefs_Issue22_Test(unittest.TestCase):
    def test_geod_nodefs(self):
        Geod("+a=6378137 +b=6378137 +no_defs")
 
+class ForwardInverseTest(unittest.TestCase):
+  pass
+
+def testcase(pj):
+  # print 'defining: ', pj
+  def TestOneProjection(self):
+    # print 'testing: ', pj
+    try:
+      p = Proj(proj=pj)
+      x,y = p(-30,40)
+      # note, for proj 4.9.2 or before the inverse projection may be missing
+      # and pyproj 1.9.5.1 or before does not test for this and will
+      # give a segmentation fault at this point:
+      lon,lat = p(x,y,inverse=True)
+    except RuntimeError:
+      pass
+  return TestOneProjection
+
+# maybe also add tests for pj_ellps?
+for pj in sorted(pj_list):
+  testname = 'test_'+pj
+  setattr(ForwardInverseTest, testname, testcase(pj))
+  
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
add a check to ensure inverse projection is defined, before calling it (needed to prevent segfaults for proj versions 4.9.2 and before).

This solves issue #43 on my system. The inverse call now throws a proper python exception if the inverse projection is not defined, in the case that the module is build without bundled proj sources.