### PR TITLE
setup.py: Parse version from _proj.pyx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,15 +86,14 @@ else:
     datafiles = [os.path.join('data',os.path.basename(f)) for f in datafiles]
     package_data = {'pyproj':datafiles}
 
-# store pyproj version information (from _proj.pyx) in version variable
+# retreive pyproj version information (stored in _proj.pyx) in version variable
 # (taken from Fiona)
 with open('_proj.pyx', 'r') as f:
     for line in f:
         if line.find("__version__") >= 0:
-            version = line.split("=")[1].strip()
-            version = version.strip('"')
-            version = version.strip("'")
-            continue
+            # parse __version__ and remove surrounding " or '
+            version = line.split("=")[1].strip()[1:-1]
+            break
 
 packages          = ['pyproj']
 package_dirs       = {'':'lib'}

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from __future__ import with_statement
 import sys, os, glob, subprocess, shutil
 from distutils import ccompiler, sysconfig
 from setuptools import setup, Extension
@@ -85,12 +86,21 @@ else:
     datafiles = [os.path.join('data',os.path.basename(f)) for f in datafiles]
     package_data = {'pyproj':datafiles}
 
+# store pyproj version information (from _proj.pyx) in version variable
+# (taken from Fiona)
+with open('_proj.pyx', 'r') as f:
+    for line in f:
+        if line.find("__version__") >= 0:
+            version = line.split("=")[1].strip()
+            version = version.strip('"')
+            version = version.strip("'")
+            continue
 
 packages          = ['pyproj']
 package_dirs       = {'':'lib'}
 
 setup(name = "pyproj",
-  version = "1.9.5.1",
+  version = version,
   description = "Python interface to PROJ.4 library",
   long_description  = """
 Performs cartographic transformations between geographic (lat/lon)


### PR DESCRIPTION
This makes _proj.pyx have the only copy of `__version__`.  The with statement requires Python 2.5.  If desired, I'll refactor the code for Python 2.4 support.  My intent is to remove one step from the process of updating the version number.

Here's what pip outputs:
```
C:\Users\mcochran\github\pyproj>pip install .
Processing c:\users\mcochran\github\pyproj
Installing collected packages: pyproj
  Running setup.py install for pyproj ... done
Successfully installed pyproj-1.9.5.1
```

Looks like pip recognizes the version number.