### PR TITLE
Travis-CI: Add Python version 2.6 to testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ python:
 
 before_install:
   - pip install $DEPENDS
+  # extra requirements to support Python 2.6  
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
 
 install:
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     - DEPENDS="numpy"
 
 python:
+  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/unittest/test.py
+++ b/unittest/test.py
@@ -1,5 +1,14 @@
 """Rewrite part of test.py in pyproj in the form of unittests."""
-import unittest
+from __future__ import with_statement
+
+from sys import version_info as sys_version_info
+
+if sys_version_info[:2] < (2 ,7):
+    # for Python 2.4 - 2.6 use the backport of unittest from Python 2.7 and onwards
+    import unittest2 as unittest
+else:
+    import unittest
+
 from pyproj import Geod, Proj, transform
 from pyproj import pj_list # , pj_ellps
 


### PR DESCRIPTION
Had to install unittest2 for Python 2.6 in order to support tests in the tests in class TypeError_Transform_Issue8_Test.  `from __future__ import with_statement` was added for Python 2.5 support.