### PR TITLE
Increase required Python version to 2.6+ & 3.2+

### DIFF
--- a/lib/pyproj/__init__.py
+++ b/lib/pyproj/__init__.py
@@ -25,7 +25,7 @@ numpy array objects).
 
 Download: http://python.org/pypi/pyproj
 
-Requirements: python 2.4 or higher.
+Requirements: Python 2.6, 2.7, 3.2 or higher version.
 
 Example scripts are in 'test' subdirectory of source distribution.
 The 'test()' function will run the examples in the docstrings.


### PR DESCRIPTION
This pull request increases the Python version to be inline with the latest release of Cython 0.23.4.  Which apparently gives a pragma error when compiled with Python version below this.  See [_proj.c line 8](https://github.com/jswhit/pyproj/blob/master/_proj.c#L8).  Another way to resolve this would be to regenerate the Cython code using version 0.20.x.

Also, there are with statements in the current code, which is enabled via a \__future__ statement in 2.5.x.

Python 2.6's support ended in October 29, 2013 with the [release of Python 2.6.9 PEP-361](https://www.python.org/dev/peps/pep-0361/).  Other project have even been getting rid of Python 2.6 support.

Travis-CI currently allows testing on Python 2.6.  There is a separate PR #51 to add that testing.  Travis-CI makes it easier to support Python versions that are not on your machine.

I think that changing support to these versions is a matter of practically that accepts the state of Python software today and anticipates the future.

[ci skip]  <-- I did't see any reason why Travis-CI should verify this commit/pull request.