### PR TITLE
Change Proj.to_latlong in order to return an instance of pyproj.Proj (clean)

### DIFF
--- a/_proj.pyx
+++ b/_proj.pyx
@@ -59,8 +59,10 @@ cdef extern from "proj_api.h":
     void pj_ctx_free( projCtx )
     int pj_ctx_get_errno( projCtx )
     projCtx pj_ctx_alloc()
-    projCtx pj_get_default_ctx()
+    projCtx pj_get_default_ctx()  
     void pj_free(projPJ)
+    # pj_dalloc: useful for deallocating stuff like i.e. pj_get_def char buffer
+    void pj_dalloc(void *) 
     void pj_set_searchpath ( int count, char **path )
     cdef enum:
         PJ_VERSION
@@ -90,6 +92,7 @@ def set_datapath(datapath):
     cdef const char *searchpath = bytestr
     pj_set_searchpath(1, &searchpath)
 
+# deprecated: used in _proj.Proj.to_latlong
 def _createproj(projstring):
     return Proj(projstring)
 
@@ -122,18 +125,36 @@ cdef class Proj:
     def to_latlong_def(self):
         """return the definition string of the geographic (lat/lon)
         coordinate version of the current projection"""
+        # This is a little hacky way of getting a latlong proj object
+        # Maybe instead of this function the __cinit__ function can take a
+        # Proj object and a type (where type = "geographic") as the libproj 
+        # java wrapper
         cdef projPJ llpj
-        llpj = pj_latlong_from_proj(self.projpj)
-        initstring = pj_get_def(llpj, 0)
-        pj_free(llpj)
-        return initstring
+        cdef char *cstring_def
+        cdef int err
 
-    def to_latlong(self):
+        llpj = pj_latlong_from_proj(self.projpj) # create temp proj
+        if llpj is not NULL:
+            cstring_def = pj_get_def(llpj, 0) # get definition c string
+            pj_free(llpj) # deallocate temp proj
+            if cstring_def is not NULL:
+                try:
+                    pystring_def = <bytes>cstring_def # copy to python string
+                    return pystring_def
+                finally:
+                    pj_dalloc(cstring_def) # deallocate c string
+
+        raise RuntimeError("could not create latlong definition")
+
+                
+    # deprecated : using in transform raised a TypeError in release 1.9.5.1
+    # reported in issue #53, resolved in #73.
+    def to_latlong(self):  
         """return a new Proj instance which is the geographic (lat/lon)
         coordinate version of the current projection"""
         cdef projPJ llpj
         llpj = pj_latlong_from_proj(self.projpj)
-        initstring = pj_get_def(llpj, 0)
+        initstring = pj_get_def(llpj, 0) # this leaks the c char buffer
         pj_free(llpj)
         return _createproj(initstring)
 

--- a/_proj.pyx
+++ b/_proj.pyx
@@ -119,6 +119,15 @@ cdef class Proj:
         pj_free(self.projpj)
         pj_ctx_free(self.projctx)
 
+    def to_latlong_def(self):
+        """return the definition string of the geographic (lat/lon)
+        coordinate version of the current projection"""
+        cdef projPJ llpj
+        llpj = pj_latlong_from_proj(self.projpj)
+        initstring = pj_get_def(llpj, 0)
+        pj_free(llpj)
+        return initstring
+
     def to_latlong(self):
         """return a new Proj instance which is the geographic (lat/lon)
         coordinate version of the current projection"""

--- a/lib/pyproj/__init__.py
+++ b/lib/pyproj/__init__.py
@@ -412,7 +412,8 @@ class Proj(_proj.Proj):
     def to_latlong(self):
         """returns an equivalent Proj in the corresponding lon/lat
         coordinates. (see pj_latlong_from_proj() in the Proj.4 C API)"""
-        return _proj.Proj.to_latlong(self)
+        string_def = _proj.Proj.to_latlong_def(self)
+        return Proj(string_def)
 
     def is_latlong(self):
         """returns True if projection in geographic (lon/lat) coordinates"""

--- a/lib/pyproj/__init__.py
+++ b/lib/pyproj/__init__.py
@@ -413,6 +413,9 @@ class Proj(_proj.Proj):
         """returns an equivalent Proj in the corresponding lon/lat
         coordinates. (see pj_latlong_from_proj() in the Proj.4 C API)"""
         string_def = _proj.Proj.to_latlong_def(self)
+        # Decode bytes --> Unicode String (for Python3)
+        if not isinstance(string_def, str):
+            string_def = string_def.decode()
         return Proj(string_def)
 
     def is_latlong(self):

--- a/unittest/test.py
+++ b/unittest/test.py
@@ -81,6 +81,14 @@ class Geod_NoDefs_Issue22_Test(unittest.TestCase):
    def test_geod_nodefs(self):
        Geod("+a=6378137 +b=6378137 +no_defs")
 
+class ProjLatLongTypeErrorTest(unittest.TestCase):  
+    # .latlong() using in transform raised a TypeError in release 1.9.5.1
+    # reported in issue #53, resolved in #72.
+    def test_latlong_typeerror(self):
+        p = Proj('+proj=stere +lon_0=-39 +lat_0=90 +lat_ts=71.0 +ellps=WGS84')
+        # if not patched this line raises a "TypeError: p2 must be a Proj class"
+        lon, lat = transform(p, p.to_latlong(), 200000, 400000)
+
 class ForwardInverseTest(unittest.TestCase):
   pass
 

--- a/unittest/test.py
+++ b/unittest/test.py
@@ -83,9 +83,10 @@ class Geod_NoDefs_Issue22_Test(unittest.TestCase):
 
 class ProjLatLongTypeErrorTest(unittest.TestCase):  
     # .latlong() using in transform raised a TypeError in release 1.9.5.1
-    # reported in issue #53, resolved in #72.
+    # reported in issue #53, resolved in #73.
     def test_latlong_typeerror(self):
         p = Proj('+proj=stere +lon_0=-39 +lat_0=90 +lat_ts=71.0 +ellps=WGS84')
+        self.assertTrue(isinstance(p, Proj))
         # if not patched this line raises a "TypeError: p2 must be a Proj class"
         lon, lat = transform(p, p.to_latlong(), 200000, 400000)
 


### PR DESCRIPTION
Returning a pyproj.Proj instance instead of the underlying base class _proj.Proj in pyproj.Proj.to_latlong function feels more intuitive.

This patch adresses a bug as well in pyproj.transform's function check. See Issue #53
**Updated from #54, #56 and #66**
This is exactly the same as #72 but based on the removal of _proj.c file. (#70)
Sorry about the multiple pull requests...
