### PR TITLE
Add __repr__ and __eq__ functions

### DIFF
--- a/_proj.pyx
+++ b/_proj.pyx
@@ -396,6 +396,11 @@ cdef class Proj:
         pj_dalloc(c_def_string)
         return py_def_string
 
+    def __repr__(self):
+        return "{modname}.{classname}({srs!r}, preserve_units=True)".format(
+                   modname=self.__module__, classname=self.__class__.__name__,
+                   srs=self.srs)
+
 def _transform(Proj p1, Proj p2, inx, iny, inz, radians):
     # private function to call pj_transform
     cdef void *xdata
@@ -498,10 +503,15 @@ cdef class Geod:
     cdef public object initstring
 
     def __cinit__(self, a, f, sphere, b, es):
-        self.initstring = '+a=%s +f=%s' % (a, f)
         geod_init(&self._geod_geodesic, <double> a, <double> f)
         self.a = a
         self.f = f
+        if isinstance(a, float) and a.is_integer():
+            # convert 'a' only for initstring
+            a = int(a)
+        if f == 0.0:
+            f = 0
+        self.initstring = '+a=%s +f=%s' % (a, f)
         self.sphere = sphere
         self.b = b
         self.es = es
@@ -668,3 +678,8 @@ cdef class Geod:
                 lats = lats + (plat2,)
                 lons = lons + (plon2,)
         return lons, lats
+
+    def __repr__(self):
+        return "{modname}.{classname}({init!r})".format(modname=self.__module__,
+                                              classname=self.__class__.__name__,
+                                              init=self.initstring)

--- a/lib/pyproj/__init__.py
+++ b/lib/pyproj/__init__.py
@@ -968,6 +968,47 @@ class Geod(_proj.Geod):
         lons, lats = _proj.Geod._npts(self, lon1, lat1, lon2, lat2, npts, radians=radians)
         return list(zip(lons, lats))
 
+    def __repr__(self):
+        # search for ellipse name
+        for (ellps, vals) in pj_ellps.items():
+            if self.a == vals['a']:
+                b = vals.get('b', None)
+                rf = vals.get('rf', None)
+                # self.sphere is True when self.f is zero or very close to
+                # zero (0), so prevent divide by zero.
+                if self.b == b or (not self.sphere and (1.0/self.f) == rf):
+                    return "{modname}.{classname}(ellps={ellps!r})" \
+                           "".format(modname=self.__module__,
+                                     classname=self.__class__.__name__,
+                                     ellps=ellps)
+
+        # no ellipse name found, call super class
+        return _proj.Geod.__repr__(self)
+
+    def __eq__(self, other):
+        """
+        equality operator == for Geod objects
+
+        Example usage:
+
+        >>> from pyproj import Geod
+        >>> gclrk1 = Geod(ellps='clrk66') # Use Clarke 1966 ellipsoid.
+        >>> gclrk2 = Geod(a=6378206.4, b=6356583.8) # Define Clarke 1966 using parameters
+        >>> gclrk1 == gclrk2
+        True
+        >>> gwgs66 = Geod('+ellps=WGS66')  # WGS 66 ellipsoid, Proj.4 style
+        >>> gnwl9d = Geod('+ellps=NWL9D')  # Naval Weapons Lab., 1965 ellipsoid
+        >>> # these ellipsoids are the same
+        >>> gnwl9d == gwgs66
+        True
+        >>> gclrk1 != gnwl9d  # Clark 1966 is unlike NWL9D
+        True
+        """
+        if not isinstance(other, _proj.Geod):
+            return False
+
+        return self.__repr__() == other.__repr__()
+
 def test():
     """run the examples in the docstrings using the doctest module"""
     import doctest, pyproj

--- a/unittest/test.py
+++ b/unittest/test.py
@@ -15,7 +15,7 @@ else:
 import math
 
 from pyproj import Geod, Proj, transform
-from pyproj import pj_list # , pj_ellps
+from pyproj import pj_list, pj_ellps
 from pyproj import proj_version_str
 
 class BasicTest(unittest.TestCase):
@@ -184,6 +184,31 @@ class GeodSharedMemoryBugTestIssue64(unittest.TestCase):
 
         az12,az21,dist_mercury = self.mercury.inv(boston_lon,boston_lat,portland_lon,portland_lat)
         self.assertLess(dist_mercury, dist_g)
+
+
+class ReprTests(unittest.TestCase):
+    # test __repr__ for Proj object
+    def test_repr(self):
+        p = Proj(proj='latlong', preserve_units=True)
+        expected = "pyproj.Proj('+proj=latlong ', preserve_units=True)"
+        self.assertEqual(repr(p), expected)
+
+    # test __repr__ for Geod object
+    def test_sphere(self):
+        # ellipse is Venus 2000 (IAU2000:29900), which is a sphere
+        g = Geod('+a=6051800 +b=6051800')
+        self.assertEqual(repr(g), "pyproj.Geod('+a=6051800 +f=0')")
+
+    # test __repr__ for Geod object
+    def test_ellps_name_round_trip(self):
+        # this could be done in a parameter fashion
+        for ellps_name in pj_ellps:
+            # skip tests, these ellipses NWL9D and WGS66 are the same
+            if ellps_name in ('NWL9D', 'WGS66'):
+                continue
+            p = Geod(ellps=ellps_name)
+            expected = "pyproj.Geod(ellps='{0}')".format(ellps_name)
+            self.assertEqual(repr(p), expected)
 
 
 class TestRadians(unittest.TestCase):


### PR DESCRIPTION
This is a redo of PR #63 without conflicts and all the extra commits.  This adds representations for Geod and Proj classes that are a little more user friendly when using the python console.

Also, this adds a Geod.\__eq\__ function, which allows comparison between Geod objects.  I had issue #15 in mind when writing this, but I'm not really sure that this is really useful. 

In order for Geod.\__repr\__ function to work as written, issue #64 had to be fixed (which was done in PR #65).