### PR TITLE
Allow package information parsing and print build debug info to stderr

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ proj_dir = os.environ.get('PROJ_DIR')
 # existing proj.4 installation.
 
 if proj_dir is not None:
-    sys.stdout.write('PROJ_DIR is set, using existing proj4 installation..\n')
+    sys.stderr.write('PROJ_DIR is set, using existing proj4 installation..\n')
     proj_libdir = os.environ.get('PROJ_LIBDIR')
     proj_incdir = os.environ.get('PROJ_INCDIR')
     libdirs=[]; incdirs = []; libraries = ['proj']
@@ -48,7 +48,7 @@ if proj_dir is not None:
 
 else:
     # use bundled proj.4
-    sys.stdout.write('using bundled proj4..\n')
+    sys.stderr.write('using bundled proj4..\n')
 
     # copy saved datadir.py back
     datadirfile = os.path.join('lib',os.path.join('pyproj','datadir.py'))
@@ -88,7 +88,7 @@ else:
             fout = os.path.basename(f.split('.lla')[0])
             fout = os.path.join(pathout,fout)
             strg = '%s %s < %s' % (cmd, fout, f)
-            sys.stdout.write('executing %s'%strg)
+            sys.stderr.write('executing %s\n'%strg)
             subprocess.call(strg,shell=True)
 
     datafiles = glob.glob(os.path.join(pathout,'*'))


### PR DESCRIPTION
The additional debug output of `setup.py` might screw up some build tools that parse it. In particular, the missing newline after the ["executing" log](https://github.com/jswhit/pyproj/blob/master/setup.py#L91) makes it hard to gather package information.

Old:
```bash
jakob@MosEisley % python2 setup.py --name
using bundled proj4..
Output Binary File Format: ctable2
Output Binary File Format: ctable2
Output Binary File Format: ctable2
Output Binary File Format: ctable2
Output Binary File Format: ctable2
Output Binary File Format: ctable2
Output Binary File Format: ctable2
Output Binary File Format: ctable2
Output Binary File Format: ctable2
Output Binary File Format: ctable2
Output Binary File Format: ctable2
executing /home/jakob/playground/pyproj/nad2bin lib/pyproj/data/null < datumgrid/null.llaexecuting /home/jakob/playground/pyproj/nad2bin lib/pyproj/data/prvi < datumgrid/prvi.llaexecuting /home/jakob/playground/pyproj/nad2bin lib/pyproj/data/MD < datumgrid/MD.llaexecuting /home/jakob/playground/pyproj/nad2bin lib/pyproj/data/WO < datumgrid/WO.llaexecuting /home/jakob/playground/pyproj/nad2bin lib/pyproj/data/alaska < datumgrid/alaska.llaexecuting /home/jakob/playground/pyproj/nad2bin lib/pyproj/data/stgeorge < datumgrid/stgeorge.llaexecuting /home/jakob/playground/pyproj/nad2bin lib/pyproj/data/FL < datumgrid/FL.llaexecuting /home/jakob/playground/pyproj/nad2bin lib/pyproj/data/TN < datumgrid/TN.llaexecuting /home/jakob/playground/pyproj/nad2bin lib/pyproj/data/hawaii < datumgrid/hawaii.llaexecuting /home/jakob/playground/pyproj/nad2bin lib/pyproj/data/stpaul < datumgrid/stpaul.llaexecuting /home/jakob/playground/pyproj/nad2bin lib/pyproj/data/stlrnc < datumgrid/stlrnc.llaexecuting /home/jakob/playground/pyprOutput Binary File Format: ctable2
Output Binary File Format: ctable2
oj/nad2bin lib/pyproj/data/WI < datumgrid/WI.llaexecuting /home/jakob/playground/pyproj/nad2bin lib/pyproj/data/conus < datumgrid/conus.llapyproj
```

New:
```bash
jakob@MosEisley % python2 setup.py --name        
using bundled proj4..
executing /home/jakob/playground/pyproj/nad2bin lib/pyproj/data/null < datumgrid/null.lla
Output Binary File Format: ctable2
executing /home/jakob/playground/pyproj/nad2bin lib/pyproj/data/prvi < datumgrid/prvi.lla
Output Binary File Format: ctable2
executing /home/jakob/playground/pyproj/nad2bin lib/pyproj/data/MD < datumgrid/MD.lla
Output Binary File Format: ctable2
executing /home/jakob/playground/pyproj/nad2bin lib/pyproj/data/WO < datumgrid/WO.lla
Output Binary File Format: ctable2
executing /home/jakob/playground/pyproj/nad2bin lib/pyproj/data/alaska < datumgrid/alaska.lla
Output Binary File Format: ctable2
executing /home/jakob/playground/pyproj/nad2bin lib/pyproj/data/stgeorge < datumgrid/stgeorge.lla
Output Binary File Format: ctable2
executing /home/jakob/playground/pyproj/nad2bin lib/pyproj/data/FL < datumgrid/FL.lla
Output Binary File Format: ctable2
executing /home/jakob/playground/pyproj/nad2bin lib/pyproj/data/TN < datumgrid/TN.lla
Output Binary File Format: ctable2
executing /home/jakob/playground/pyproj/nad2bin lib/pyproj/data/hawaii < datumgrid/hawaii.lla
Output Binary File Format: ctable2
executing /home/jakob/playground/pyproj/nad2bin lib/pyproj/data/stpaul < datumgrid/stpaul.lla
Output Binary File Format: ctable2
executing /home/jakob/playground/pyproj/nad2bin lib/pyproj/data/stlrnc < datumgrid/stlrnc.lla
Output Binary File Format: ctable2
executing /home/jakob/playground/pyproj/nad2bin lib/pyproj/data/WI < datumgrid/WI.lla
Output Binary File Format: ctable2
executing /home/jakob/playground/pyproj/nad2bin lib/pyproj/data/conus < datumgrid/conus.lla
Output Binary File Format: ctable2
pyproj
```
```bash
jakob@MosEisley % python2 setup.py --name 2>/dev/null 
pyproj
```