### PR TITLE
Doctest: add exit code for Travis of the number of failed doctests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - python setup.py install
 
 script:
-    - python -c "import pyproj; pyproj.test()"
+    - python lib/pyproj/__init__.py
     - python -c "import pyproj; pyproj.Proj(init='epsg:4269')"
     - python unittest/test.py -v
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -97,7 +97,7 @@ build_script:
 
 test_script:
   # Run the project tests
-  - "%CMD_IN_ENV% python -c \"import pyproj; pyproj.test()\""
+  - "%CMD_IN_ENV% python lib/pyproj/__init__.py"
   - "%CMD_IN_ENV% python -c \"import pyproj; pyproj.Proj(init='epsg:4269')\""
   - "%CMD_IN_ENV% python unittest/test.py -v"
 

--- a/lib/pyproj/__init__.py
+++ b/lib/pyproj/__init__.py
@@ -921,8 +921,6 @@ class Geod(_proj.Geod):
         >>> from pyproj import Geod
         >>> g = Geod(ellps='clrk66') # Use Clarke 1966 ellipsoid.
         >>> # specify the lat/lons of Boston and Portland.
-        >>> g = Geod(ellps='clrk66') # Use Clarke 1966 ellipsoid.
-        >>> # specify the lat/lons of Boston and Portland.
         >>> boston_lat = 42.+(15./60.); boston_lon = -71.-(7./60.)
         >>> portland_lat = 45.+(31./60.); portland_lon = -123.-(41./60.)
         >>> # find ten equally spaced points between Boston and Portland.
@@ -961,6 +959,7 @@ class Geod(_proj.Geod):
 def test():
     """run the examples in the docstrings using the doctest module"""
     import doctest, pyproj
-    doctest.testmod(pyproj,verbose=True)
+    failure_count, test_count = doctest.testmod(pyproj,verbose=True)
+    return failure_count
 
-if __name__ == "__main__": test()
+if __name__ == "__main__": sys.exit(test())


### PR DESCRIPTION
This was found during a commit of PR #78 that a doctest failed, but passed in Travis.  This change will cause Travis to fail when a doctest fails. 

Also, remove duplicate lines in doctest for Geod class.