### PR TITLE
TEST: Use nose2 for unit test framework. Add coverage for python and …

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+plugins = Cython.Coverage
+
+[report]
+# number of decimal points to report for coverage percentage
+precision = 2

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,10 @@ build/
 nad2bin*
 *.obj
 *.o
+*.pyc
+*.so
 _proj.c
+.coverage
 dist/
 lib/pyproj.egg-info/
 lib/pyproj/data/FL

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,16 +43,17 @@ before_install:
       ci/travis/proj-dl-and-compile "$PROJSOURCE"
       export PROJ_DIR="/tmp/proj_dl_install"
     fi
-  # Download PROJ.4 repo and compile
-  # - if [[ $PROJSOURCE == "git" ]]; then ci/travis/proj4-git-download-and-compile; export PROJ_DIR="/tmp/proj_git_install"; fi
+
+  # add line to the top of _proj.pyx enabling coverage for Cython code
+  - ./ci/travis/add_line_proj_pyx.sh
   
 install:
-  - python setup.py install
+  # coverage report requires a local install
+  - PYPROJ_FULL_COVERAGE=YES pip install -e .
 
 script:
-    - python lib/pyproj/__init__.py
     - python -c "import pyproj; pyproj.Proj(init='epsg:4269')"
-    - python unittest/test.py -v
+    - nose2 -v
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ pyproj
 Installation
 ------------
 * clone github repo or download source release at http://python.org/pypi/pyproj.
-* If you clone the github repo, (Cython)[http://cython.org/] is a dependency.
+  * If you clone the github repo, [Cython](http://cython.org/) is a dependency.
 * python setup.py build
 * python setup.py install (with sudo if necessary).
 
@@ -19,9 +19,58 @@ Examples of how to set the PROJ_DIR environment variable:
 
 Testing
 -------
-To test, run `python -c "import pyproj; pyproj.test()"`
+[nose2](https://github.com/nose-devs/nose2) is required to run some tests.
+There are two testing suites: doctests and unittests. Doctests are located in
+lib/pyproj/\__init\__.py.  Unittests are located in unittest/.
 
-For new unit tests, run `python unittest/test.py`
+To run all tests  (add `-v` option to add verbose output):
+```
+    nose2 [-v]
+```
+
+To run only the doctest:
+```
+    python -c "import pyproj; pyproj.test()"
+```
+
+To run only the unittests:
+```
+    python unittest/test.py [-v]
+OR:
+    nose2 unittest/test.py [-v]
+```
+
+Code Coverage
+-------------
+nose2 will automatically produce coverage for python files.  In order to
+get coverage for the Cython code there are a couple extra steps needed.
+Travis-CI should be set up to measure this automatically.
+
+* Download pyproj source.
+* Install Cython, and all  other testing requirements
+```
+  pip install -r requirements-dev.txt
+```
+
+* Add this line to top of _proj.pyx
+```
+  # cython: linetrace=True
+```
+
+* Set the environment variable PYPROJ_FULL_COVERAGE to any value.  This
+  is only needed for installation. Most platforms `$ export PYPROJ_FULL_COVERGAGE=1`.
+  Windows: `C:...> set PYPROJ_FULL_COVERGAGE=1`,
+
+* Install in editable/development mode (python setup.py uses the `--inplace` flag)
+  * Using pip, use `--upgrade` flag if pyproj is already installed.
+```
+    pip install [--upgrade] --editable .
+```
+  * Using python setup.py (this isn't well tested)
+```
+    python setup.py build_ext --inplace
+    python setup.py install
+```
 
 Documentation
 -------------

--- a/_proj.pyx
+++ b/_proj.pyx
@@ -1,3 +1,5 @@
+
+
 #cimport c_numpy
 #c_numpy.import_array()
 

--- a/ci/travis/add_line_proj_pyx.sh
+++ b/ci/travis/add_line_proj_pyx.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# adds this line to _proj.pyx to enable measuring Cython coverage
+sed -i '1 i\# cython: linetrace=True' _proj.pyx

--- a/lib/pyproj/__init__.py
+++ b/lib/pyproj/__init__.py
@@ -1009,10 +1009,15 @@ class Geod(_proj.Geod):
 
         return self.__repr__() == other.__repr__()
 
-def test():
+def test(**kwargs):
     """run the examples in the docstrings using the doctest module"""
-    import doctest, pyproj
-    failure_count, test_count = doctest.testmod(pyproj,verbose=True)
+    import doctest
+    import pyproj
+
+    verbose = kwargs.get('verbose')
+    failure_count, test_count = doctest.testmod(pyproj, verbose=verbose)
+
     return failure_count
 
-if __name__ == "__main__": sys.exit(test())
+if __name__ == "__main__": 
+    sys.exit(test(verbose=True))

--- a/nose2.cfg
+++ b/nose2.cfg
@@ -1,0 +1,8 @@
+[unittest]
+start-dir = unittest
+
+[coverage]
+always-on = True
+coverage = ./_proj.pyx
+           lib/pyproj
+coverage-report = term

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,5 @@
 numpy
 cython>=0.23.5
+nose2
+cov-core
+coverage>=4.0

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,10 @@ else:
     #macros.append(('HAVE_STRERROR',1))
     # for win32 threads
     #macros.append(('MUTEX_win32',1))
+    # Set environment variable PYPROJ_FULL_COVERAGE to any value
+    if os.environ.get('PYPROJ_FULL_COVERAGE') is not None:
+        # compiler flag required for Cython Coverage
+        macros.append(('CYTHON_TRACE',1))
     extensions = [Extension("pyproj._proj",deps+['_proj'+ext],
                   include_dirs=['src'],define_macros=macros)]
 

--- a/unittest/test_doctest_wrapper.py
+++ b/unittest/test_doctest_wrapper.py
@@ -1,0 +1,13 @@
+"""
+This is a wrapper for the doctests in lib/pyproj/__init__.py so that
+nose2 can conveniently run all the tests in a single command line.
+"""
+
+import pyproj
+
+
+def test_doctests():
+    failure_count = pyproj.test()
+    # if the below line fails, doctests have failed
+    assert failure_count == 0, "{0} of the doctests in " \
+        "lib/pyproj/__init__.py failed".format(failure_count)


### PR DESCRIPTION
…cython code. Simplify ForwardInverseTest unit test class using nose2 parameterized decorator. Documentation for testing changes. Add a few lines to .gitignore for a few more files that should not end up in the repo.  Add documentation for coverage and testing. Small documentation cleanup.

Cython coverage doesn't work when not using included copy of PROJ.4--I can probably accept that.  README.md needs a little cleanup.

Not quiet ready to merge.