### PR TITLE
Sort input file list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ else:
     if os.path.isfile(datadirfile_save):
         shutil.move(datadirfile_save, datadirfile)
 
-    deps = glob.glob('src/*.c')
+    deps = sorted(glob.glob('src/*.c'))
     macros = []
     # these flags are set by configure when proj.4 lib is built.
     # enable pthreads support


### PR DESCRIPTION
so that the .so file builds in a reproducible way
in spite of indeterministic filesystem readdir order
and http://bugs.python.org/issue30461

See https://reproducible-builds.org/ for why this is good.

This PR was done while working on reproducible builds for openSUSE.