### PR TITLE
Make nad2bin output reproducible

### DIFF
--- a/nad2bin.c
+++ b/nad2bin.c
@@ -71,6 +71,7 @@ int main(int argc, char **argv) {
     const char *SUB_NAME = "";
     const char *CREATED  = "";
     const char *UPDATED  = "";
+    memset(&ct, 0, sizeof(ct));
 
 /* ==================================================================== */
 /*      Process arguments.                                              */


### PR DESCRIPTION
initialize the struct CTABLE

Without this patch,
./nad2bin /tmp/x < datumgrid/stpaul.lla && md5sum /tmp/x
would differ after byte 41 because uninitialized memory was written
to the file and ASLR randomized the memory content

See https://reproducible-builds.org/ for why this matters.