### PR TITLE
Add installation instructions for pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ Examples of how to set the PROJ_DIR environment variable:
 * Windows - `C:\...> set PROJ_DIR=C:\OSGeo4W\`
 * Linux/OS X on most shells- `$ export PROJ_DIR=/lib/`
 
+An alternative way to install is with `pip`:
+
+```
+pip install cython
+pip install git+https://github.com/jswhit/pyproj.git
+```
+
+You migh want to run pip with administrative privilegies (e.g. `sudo pip`) or
+perform an user only installation (e.g. `pip install --user`).
+
 Testing
 -------
 [nose2](https://github.com/nose-devs/nose2) is required to run some tests.

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ pip install cython
 pip install git+https://github.com/jswhit/pyproj.git
 ```
 
-You migh want to run pip with administrative privilegies (e.g. `sudo pip`) or
-perform an user only installation (e.g. `pip install --user`).
+You may need to run pip with administrative privileges (e.g. `sudo pip`) or
+perform a user only installation (e.g. `pip install --user`).
 
 Testing
 -------


### PR DESCRIPTION
Several issues report problems with using `pip install pyproj`. A workaround is using the latest version from Github.

Some issues with pip problems: #141 #136 #133 #132 #130 #59 #25 #13 #9.