### PR TITLE
Perform minimal actions in clean target.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,13 +10,14 @@ from glob import glob
 from setuptools import Extension, setup
 
 # Use Cython if available.
-try:
-    from Cython.Build import cythonize
-except ImportError:
-    sys.exit(
-        "ERROR: Cython.Build.cythonize not found. "
-        "Cython is required to build from a repo."
-    )
+if "clean" not in sys.argv:
+    try:
+        from Cython.Build import cythonize
+    except ImportError:
+        sys.exit(
+            "ERROR: Cython.Build.cythonize not found. "
+            "Cython is required to build from a repo."
+        )
 
 
 PROJ_MIN_VERSION = (6, 0, 0)
@@ -57,86 +58,89 @@ if os.environ.get("PROJ_WHEEL") is not None and os.path.exists(INTERNAL_PROJ_DIR
         os.path.join(BASE_INTERNAL_PROJ_DIR, "share", "proj", "*")
     )
 
-if proj_dir is None and os.path.exists(INTERNAL_PROJ_DIR):
-    proj_dir = INTERNAL_PROJ_DIR
-    print("Internally compiled directory being used {}.".format(INTERNAL_PROJ_DIR))
-elif proj_dir is None and not os.path.exists(INTERNAL_PROJ_DIR):
-    proj = find_executable("proj")
-    if proj is None:
-        sys.exit("Proj executable not found. Please set PROJ_DIR variable.")
-    proj_dir = os.path.dirname(os.path.dirname(proj))
-elif proj_dir is not None and os.path.exists(proj_dir):
-    print("PROJ_DIR is set, using existing proj4 installation..\n")
-else:
-    sys.exit("ERROR: Invalid path for PROJ_DIR {}".format(proj_dir))
-
-# check_proj_version
-check_proj_version(proj_dir)
-
-# Configure optional Cython coverage.
-cythonize_options = {"language_level": sys.version_info[0]}
-if os.environ.get("PYPROJ_FULL_COVERAGE"):
-    cythonize_options["compiler_directives"] = {"linetrace": True}
-    cythonize_options["annotate"] = True
-
-
-proj_libdir = os.environ.get("PROJ_LIBDIR")
-libdirs = []
-if proj_libdir is None:
-    libdir_search_paths = (
-        os.path.join(proj_dir, "lib"),
-        os.path.join(proj_dir, "lib64"),
-    )
-    for libdir_search_path in libdir_search_paths:
-        if os.path.exists(libdir_search_path):
-            libdirs.append(libdir_search_path)
-    if not libdirs:
-        sys.exit("ERROR: PROJ_LIBDIR dir not found. Please set PROJ_LIBDIR.")
-else:
-    libdirs.append(proj_libdir)
-
-if os.environ.get("PROJ_WHEEL") is not None and os.path.exists(
-    os.path.join(BASE_INTERNAL_PROJ_DIR, "lib")
-):
-    package_data["pyproj"].append(os.path.join(BASE_INTERNAL_PROJ_DIR, "lib", "*"))
-
-
-proj_incdir = os.environ.get("PROJ_INCDIR")
-incdirs = []
-if proj_incdir is None:
-    if os.path.exists(os.path.join(proj_dir, "include")):
-        incdirs.append(os.path.join(proj_dir, "include"))
+if "clean" not in sys.argv:
+    if proj_dir is None and os.path.exists(INTERNAL_PROJ_DIR):
+        proj_dir = INTERNAL_PROJ_DIR
+        print("Internally compiled directory being used {}.".format(INTERNAL_PROJ_DIR))
+    elif proj_dir is None and not os.path.exists(INTERNAL_PROJ_DIR):
+        proj = find_executable("proj")
+        if proj is None:
+            sys.exit("Proj executable not found. Please set PROJ_DIR variable.")
+        proj_dir = os.path.dirname(os.path.dirname(proj))
+    elif proj_dir is not None and os.path.exists(proj_dir):
+        print("PROJ_DIR is set, using existing proj4 installation..\n")
     else:
-        sys.exit("ERROR: PROJ_INCDIR dir not found. Please set PROJ_INCDIR.")
+        sys.exit("ERROR: Invalid path for PROJ_DIR {}".format(proj_dir))
+
+    # check_proj_version
+    check_proj_version(proj_dir)
+
+    # Configure optional Cython coverage.
+    cythonize_options = {"language_level": sys.version_info[0]}
+    if os.environ.get("PYPROJ_FULL_COVERAGE"):
+        cythonize_options["compiler_directives"] = {"linetrace": True}
+        cythonize_options["annotate"] = True
+
+
+    proj_libdir = os.environ.get("PROJ_LIBDIR")
+    libdirs = []
+    if proj_libdir is None:
+        libdir_search_paths = (
+            os.path.join(proj_dir, "lib"),
+            os.path.join(proj_dir, "lib64"),
+        )
+        for libdir_search_path in libdir_search_paths:
+            if os.path.exists(libdir_search_path):
+                libdirs.append(libdir_search_path)
+        if not libdirs:
+            sys.exit("ERROR: PROJ_LIBDIR dir not found. Please set PROJ_LIBDIR.")
+    else:
+        libdirs.append(proj_libdir)
+
+    if os.environ.get("PROJ_WHEEL") is not None and os.path.exists(
+        os.path.join(BASE_INTERNAL_PROJ_DIR, "lib")
+    ):
+        package_data["pyproj"].append(os.path.join(BASE_INTERNAL_PROJ_DIR, "lib", "*"))
+
+
+    proj_incdir = os.environ.get("PROJ_INCDIR")
+    incdirs = []
+    if proj_incdir is None:
+        if os.path.exists(os.path.join(proj_dir, "include")):
+            incdirs.append(os.path.join(proj_dir, "include"))
+        else:
+            sys.exit("ERROR: PROJ_INCDIR dir not found. Please set PROJ_INCDIR.")
+    else:
+        incdirs.append(proj_incdir)
+
+    libraries = ["proj"]
+    if os.name == "nt":
+        for libdir in libdirs:
+            projlib = glob(os.path.join(libdir, "proj*.lib"))
+            if projlib:
+                libraries = [os.path.basename(projlib[0]).split(".lib")[0]]
+                break
+
+    ext_options = dict(
+        include_dirs=incdirs,
+        library_dirs=libdirs,
+        runtime_library_dirs=libdirs if os.name != "nt" else None,
+        libraries=libraries,
+    )
+    if os.name != "nt":
+        ext_options["embedsignature"] = True
+
+    ext_modules = cythonize(
+        [
+            Extension("pyproj._proj", ["pyproj/_proj.pyx"], **ext_options),
+            Extension("pyproj._geod", ["pyproj/_geod.pyx"], **ext_options),
+            Extension("pyproj._crs", ["pyproj/_crs.pyx"], **ext_options),
+        ],
+        quiet=True,
+        **cythonize_options
+    )
 else:
-    incdirs.append(proj_incdir)
-
-libraries = ["proj"]
-if os.name == "nt":
-    for libdir in libdirs:
-        projlib = glob(os.path.join(libdir, "proj*.lib"))
-        if projlib:
-            libraries = [os.path.basename(projlib[0]).split(".lib")[0]]
-            break
-
-ext_options = dict(
-    include_dirs=incdirs,
-    library_dirs=libdirs,
-    runtime_library_dirs=libdirs if os.name != "nt" else None,
-    libraries=libraries,
-)
-if os.name != "nt":
-    ext_options["embedsignature"] = True
-
-ext_modules = cythonize(
-    [
-        Extension("pyproj._proj", ["pyproj/_proj.pyx"], **ext_options),
-        Extension("pyproj._geod", ["pyproj/_geod.pyx"], **ext_options),
-        Extension("pyproj._crs", ["pyproj/_crs.pyx"], **ext_options),
-    ],
-    quiet=True,
-    **cythonize_options
-)
+    ext_modules = []
 
 # retreive pyproj version information (stored in _proj.pyx) in version variable
 # (taken from Fiona)


### PR DESCRIPTION
The clean target is called outside the build chroot when building
Debian packages. Only inside the chroot will dependencies be available.

Cythonize changes the source tree which should only happen in build target.